### PR TITLE
TSCONFIG-2 bump version number to be equal to manually published version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdigit/typescript-config",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "typescript configuration",
   "scripts": {
     "prepublishOnly": "publish",


### PR DESCRIPTION
No label needed. We want this to be the same as the manually published version.